### PR TITLE
Add Terraform fmt and Helm lint to CI, upgrade Trivy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive terraform/
+
+      - name: Helm lint
+        run: helm lint helm/
+
       - name: Trivy (config & fs)
-        uses: aquasecurity/trivy-action@0.26.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           format: 'table'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ terraform {
       source  = "goharbor/harbor"
       version = ">= 3.10.0"
     }
-      kubernetes = {
+    kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">= 2.38.0"
     }
@@ -22,23 +22,23 @@ provider "kubernetes" {
 }
 
 resource "harbor_project" "psp" {
-  name   = "psp"
-  public = false
+  name                   = "psp"
+  public                 = false
   vulnerability_scanning = true
-  deployment_security = "high"
+  deployment_security    = "high"
   # enable_content_trust_cosign = true
 }
 
 resource "harbor_project" "psp_solvers" {
-  name   = "psp-solvers"
-  public = false
+  name                   = "psp-solvers"
+  public                 = false
   vulnerability_scanning = true
-  deployment_security = "high"
+  deployment_security    = "high"
   # enable_content_trust_cosign = true
 }
 
 resource "harbor_interrogation_services" "main" {
-  default_scanner = "Trivy"
+  default_scanner           = "Trivy"
   vulnerability_scan_policy = "Daily"
 }
 
@@ -46,24 +46,24 @@ resource "harbor_interrogation_services" "main" {
 resource "harbor_robot_account" "cd" {
   name        = "cd"
   description = "CD robot with push permission"
-  duration    = -1            
-  level       = "project"     
+  duration    = -1
+  level       = "project"
 
   permissions {
     kind      = "project"
-    namespace = harbor_project.psp.name   
+    namespace = harbor_project.psp.name
 
     access {
       resource = "repository"
       action   = "push"
       effect   = "allow"
     }
-    
+
   }
 }
 
 output "robot_name" {
-  value = harbor_robot_account.cd.name    
+  value = harbor_robot_account.cd.name
 }
 
 output "robot_secret" {
@@ -107,8 +107,8 @@ resource "harbor_robot_account" "pull" {
 resource "harbor_robot_account" "push" {
   name        = "push"
   description = "A robot that enables the solver director to push images into the solvers project"
-  duration    = -1            
-  level       = "project"     
+  duration    = -1
+  level       = "project"
 
   permissions {
     kind      = "project"


### PR DESCRIPTION
## Summary
- Add `hashicorp/setup-terraform` and `terraform fmt -check` step to CI
- Add `helm lint` step to CI
- Upgrade `trivy-action` from 0.26.0 to 0.35.0

## Test plan
- [ ] Verify CI passes with the new lint steps
- [ ] Verify Trivy still reports correctly with the upgraded version

🤖 Generated with [Claude Code](https://claude.com/claude-code)